### PR TITLE
Retrieve Spoken Text Using TTS Metadata

### DIFF
--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -846,7 +846,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             return "", 0
 
         elapsed_ms = (time.time() - app_config.playout_start_time) * 1000
-        return self.get_spoken_text_at_time(elapsed_ms)
+        return self._get_spoken_text_at_time(elapsed_ms)
 
     async def _play_speech(self, speech_handle: SpeechHandle) -> None:
         await self._agent_publication.wait_for_subscription()
@@ -993,7 +993,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     if collected_text in (
                         AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     ):
-                        # AppConfig().agent_interrupted = True
+                        AppConfig().agent_interrupted = True
                         app_config_text = AppConfig().call_metadata.get(
                             "agent_interrupted_text"
                         )

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -804,7 +804,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         self._transcribed_text = self._transcribed_text[len(user_question) :]
         speech_handle.mark_user_committed()
 
-    def _get_spoken_text_at_time(self, elapsed_ms: float) -> Tuple[str, int]:
+    def _get_spoken_text_at_time(self, elapsed_ms: float) -> str:
         """
         Get the text that has been spoken up to a specific elapsed time.
 
@@ -822,6 +822,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         # Find the last character that should have been spoken
         for i, char in enumerate(app_config.playout_buffer):
+            logger.info(f"char: {char}")
             duration = app_config.char_timings[i]
             duration_sum += duration
             # If this character's end time is beyond our elapsed time, we've found our cutoff
@@ -843,8 +844,10 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         """
         app_config = AppConfig()
         if not app_config.playout_start_time:
-            return "", 0
+            logger.info("No playout start time found")
+            return ""
 
+        logger.info(f"playout_start_time: {app_config.playout_start_time}")
         elapsed_ms = (time.time() - app_config.playout_start_time) * 1000
         logger.info(f"elapsed_ms: {elapsed_ms}")
         logger.info(f"spoken so far: {self._get_spoken_text_at_time(elapsed_ms)}")

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -966,7 +966,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         _commit_user_question_if_needed()
 
-        collected_text = self._get_current_spoken_text()
+        collected_text = speech_handle.synthesis_handle.tts_forwarder.played_text
         interrupted = speech_handle.interrupted
         is_using_tools = isinstance(speech_handle.source, LLMStream) and len(
             speech_handle.source.function_calls
@@ -994,9 +994,13 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     if collected_text in (
                         AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     ):
+                        app_config_text = AppConfig().call_metadata.get('agent_interrupted_text')
+                        current_text = self._get_current_spoken_text()
+                        text_to_replace = current_text if current_text else app_config_text
                         logger.info(
-                            f"Replacing interrupted text=`{collected_text}` with `{collected_text}`"
+                            f"Replacing interrupted text=`{collected_text}` with `{text_to_replace}`"
                         )
+                        collected_text = text_to_replace
                     collected_text += "..."
 
                 msg = ChatMessage.create(text=collected_text, role="assistant")

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1014,6 +1014,18 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                             f"Replacing interrupted text=`{collected_text}` with `{current_text}`"
                         )
                         collected_text = current_text + "..."
+                        logger.info(
+                            f"inside interrupt case, about to clear playout_buffer: {AppConfig().playout_buffer}"
+                        )
+                        AppConfig().playout_buffer = ""
+                        AppConfig().char_timings = []
+                else:
+                    if collected_text == AppConfig().last_llm_message:
+                        logger.info(
+                            f"inside collected_text == AppConfig().last_llm_message, about to clear playout_buffer: {AppConfig().playout_buffer}"
+                        )
+                        AppConfig().playout_buffer = ""
+                        AppConfig().char_timings = []
 
                 msg = ChatMessage.create(text=collected_text, role="assistant")
                 self._chat_ctx.messages.append(msg)

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -832,7 +832,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         return "".join(spoken_chars)
 
-    def _get_current_spoken_text(self) -> Tuple[str, int]:
+    def _get_current_spoken_text(self) -> str:
         """
         Get the text that has been spoken so far based on current time.
 
@@ -1000,8 +1000,11 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     # app_config_text = AppConfig().call_metadata.get(
                     #     "agent_interrupted_text"
                     # )
-                    current_text = self._get_current_spoken_text()
-                    if collected_text in current_text and collected_text != current_text
+                    current_text = self._get_current_spoken_text() or ""
+                    if (
+                        collected_text in current_text
+                        and collected_text != current_text
+                    ):
                         logger.info(
                             f"Replacing interrupted text=`{collected_text}` with `{current_text}`"
                         )

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -13,8 +13,8 @@ from typing import (
     Literal,
     Optional,
     Protocol,
-    Union,
     Tuple,
+    Union,
 )
 
 from app_config import AppConfig
@@ -788,7 +788,6 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             SpeechDataContextVar.reset(tk)
 
     def _commit_user_question(self) -> None:
-
         speech_handle = self._playing_speech
         synthesis_handle = speech_handle.synthesis_handle
         play_handle = synthesis_handle.play()
@@ -804,7 +803,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         self._transcribed_text = self._transcribed_text[len(user_question) :]
         speech_handle.mark_user_committed()
-    
+
     def _get_spoken_text_at_time(self, elapsed_ms: float) -> Tuple[str, int]:
         """
         Get the text that has been spoken up to a specific elapsed time.
@@ -994,10 +993,14 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     if collected_text in (
                         AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     ):
-                        AppConfig().agent_interrupted = True
-                        app_config_text = AppConfig().call_metadata.get('agent_interrupted_text')
+                        # AppConfig().agent_interrupted = True
+                        app_config_text = AppConfig().call_metadata.get(
+                            "agent_interrupted_text"
+                        )
                         current_text = self._get_current_spoken_text()
-                        text_to_replace = current_text if current_text else app_config_text
+                        text_to_replace = (
+                            current_text if current_text else app_config_text
+                        )
                         logger.info(
                             f"Replacing interrupted text=`{collected_text}` with `{text_to_replace}`"
                         )
@@ -1044,9 +1047,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 return
 
             assert isinstance(speech_handle.source, LLMStream)
-            assert (
-                not user_question or speech_handle.user_committed
-            ), "user speech should have been committed before using tools"
+            assert not user_question or speech_handle.user_committed, (
+                "user speech should have been committed before using tools"
+            )
 
             llm_stream = speech_handle.source
 
@@ -1172,9 +1175,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         speech_id: str,
         source: str | LLMStream | AsyncIterable[str],
     ) -> SynthesisHandle:
-        assert (
-            self._agent_output is not None
-        ), "agent output should be initialized when ready"
+        assert self._agent_output is not None, (
+            "agent output should be initialized when ready"
+        )
 
         tk = SpeechDataContextVar.set(SpeechData(speech_id))
 

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1026,7 +1026,10 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                         AppConfig().char_timings = []
                 else:
                     logger.info(f"interrupted=False")
-                    if collected_text == AppConfig().last_llm_message:
+                    if (
+                        collected_text.replace(" ", "").lower()
+                        == AppConfig().last_llm_message.replace(" ", "").lower()
+                    ):
                         logger.info(
                             f"inside collected_text == AppConfig().last_llm_message, about to clear playout_buffer: {AppConfig().playout_buffer}"
                         )

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -993,22 +993,19 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             if collected_text:
                 if interrupted:
                     logger.info(f"interrupted=True; collected_text: {collected_text}")
-                    if collected_text in (
-                        AppConfig().call_metadata.get("agent_interrupted_text") or ""
-                    ):
-                        AppConfig().agent_interrupted = True
-                        app_config_text = AppConfig().call_metadata.get(
-                            "agent_interrupted_text"
-                        )
-                        current_text = self._get_current_spoken_text()
-                        text_to_replace = (
-                            current_text if current_text else app_config_text
-                        )
+                    # if collected_text in (
+                    #     AppConfig().call_metadata.get("agent_interrupted_text") or ""
+                    # ):
+                    AppConfig().agent_interrupted = True
+                    # app_config_text = AppConfig().call_metadata.get(
+                    #     "agent_interrupted_text"
+                    # )
+                    current_text = self._get_current_spoken_text()
+                    if collected_text in current_text and collected_text != current_text
                         logger.info(
-                            f"Replacing interrupted text=`{collected_text}` with `{text_to_replace}`"
+                            f"Replacing interrupted text=`{collected_text}` with `{current_text}`"
                         )
-                        collected_text = text_to_replace
-                    collected_text += "..."
+                        collected_text = current_text + "..."
 
                 msg = ChatMessage.create(text=collected_text, role="assistant")
                 self._chat_ctx.messages.append(msg)

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -992,6 +992,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
             if collected_text:
                 if interrupted:
+                    logger.info(f"interrupted=True; collected_text: {collected_text}")
                     if collected_text in (
                         AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     ):

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -994,6 +994,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     if collected_text in (
                         AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     ):
+                        AppConfig().agent_interrupted = True
                         app_config_text = AppConfig().call_metadata.get('agent_interrupted_text')
                         current_text = self._get_current_spoken_text()
                         text_to_replace = current_text if current_text else app_config_text

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -816,14 +816,16 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             - The text spoken up to that time
             - The index of the last spoken character
         """
-        app_config = AppConfig()
         spoken_chars = []
         duration_sum = 0
 
+        logger.info(
+            f"inside _get_spoken_text_at_time, playout_buffer: {AppConfig().playout_buffer}"
+        )
         # Find the last character that should have been spoken
-        for i, char in enumerate(app_config.playout_buffer):
+        for i, char in enumerate(AppConfig().playout_buffer):
             logger.info(f"char: {char}")
-            duration = app_config.char_timings[i]
+            duration = AppConfig().char_timings[i]
             duration_sum += duration
             # If this character's end time is beyond our elapsed time, we've found our cutoff
             if duration_sum > elapsed_ms:

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -846,6 +846,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             return "", 0
 
         elapsed_ms = (time.time() - app_config.playout_start_time) * 1000
+        logger.info(f"elapsed_ms: {elapsed_ms}")
+        logger.info(f"spoken so far: {self._get_spoken_text_at_time(elapsed_ms)}")
         return self._get_spoken_text_at_time(elapsed_ms)
 
     async def _play_speech(self, speech_handle: SpeechHandle) -> None:

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -852,7 +852,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         logger.info(f"playout_start_time: {app_config.playout_start_time}")
         elapsed_ms = (time.time() - app_config.playout_start_time) * 1000
         logger.info(f"elapsed_ms: {elapsed_ms}")
-        logger.info(f"spoken so far: {self._get_spoken_text_at_time(elapsed_ms)}")
+        logger.info(
+            f"_get_current_spoken_text: {self._get_spoken_text_at_time(elapsed_ms)}"
+        )
         return self._get_spoken_text_at_time(elapsed_ms)
 
     async def _play_speech(self, speech_handle: SpeechHandle) -> None:
@@ -996,8 +998,11 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 self._chat_ctx.messages.extend(speech_handle.extra_tools_messages)
 
             if collected_text:
+                logger.info(
+                    f"collected_text: {collected_text}, last_llm_message: {AppConfig().last_llm_message}"
+                )
                 if interrupted:
-                    logger.info(f"interrupted=True; collected_text: {collected_text}")
+                    logger.info(f"interrupted=True")
                     # if collected_text in (
                     #     AppConfig().call_metadata.get("agent_interrupted_text") or ""
                     # ):
@@ -1020,6 +1025,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                         AppConfig().playout_buffer = ""
                         AppConfig().char_timings = []
                 else:
+                    logger.info(f"interrupted=False")
                     if collected_text == AppConfig().last_llm_message:
                         logger.info(
                             f"inside collected_text == AppConfig().last_llm_message, about to clear playout_buffer: {AppConfig().playout_buffer}"

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -852,8 +852,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         logger.info(f"playout_start_time: {app_config.playout_start_time}")
         elapsed_ms = (time.time() - app_config.playout_start_time) * 1000
         logger.info(f"elapsed_ms: {elapsed_ms}")
+
         logger.info(
-            f"_get_current_spoken_text: {self._get_spoken_text_at_time(elapsed_ms)}"
+            f"Inside _get_current_spoken_text, about to return: {self._get_spoken_text_at_time(elapsed_ms)}"
         )
         return self._get_spoken_text_at_time(elapsed_ms)
 
@@ -1011,6 +1012,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     #     "agent_interrupted_text"
                     # )
                     current_text = self._get_current_spoken_text() or ""
+                    logger.info(f"current_text: {current_text}")
                     if (
                         collected_text in current_text
                         and collected_text != current_text

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1014,8 +1014,10 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     current_text = self._get_current_spoken_text() or ""
                     logger.info(f"current_text: {current_text}")
                     if (
-                        collected_text in current_text
-                        and collected_text != current_text
+                        collected_text.replace(" ", "").lower()
+                        in current_text.replace(" ", "").lower()
+                        and collected_text.replace(" ", "").lower()
+                        != current_text.replace(" ", "").lower()
                     ):
                         logger.info(
                             f"Replacing interrupted text=`{collected_text}` with `{current_text}`"

--- a/livekit-agents/livekit/agents/transcription/tts_forwarder.py
+++ b/livekit-agents/livekit/agents/transcription/tts_forwarder.py
@@ -14,6 +14,9 @@ from ..log import logger
 from ..tokenize.tokenizer import PUNCTUATIONS
 from . import _utils
 
+from app_config import AppConfig
+
+
 # 3.83 is the "baseline", the number of hyphens per second TTS returns in avg.
 STANDARD_SPEECH_RATE = 3.83
 
@@ -308,6 +311,7 @@ class TTSSegmentsForwarder:
 
                     sentence_stream = text_data.sentence_stream
                     forward_start_time = time.time()
+                    AppConfig().playout_start_time = forward_start_time
 
                     async for ev in sentence_stream:
                         await self._sync_sentence_co(

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -568,6 +568,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                         if alignment := data.get("normalizedAlignment"):
                             # Add character timing data to the forwarder
                             if AppConfig().was_last_batch_of_char_timings:
+                                logger.info(
+                                    f"just cleared playout_buffer, current={AppConfig().playout_buffer}"
+                                )
                                 AppConfig().playout_buffer = ""
                                 AppConfig().char_timings = []
                                 AppConfig().was_last_batch_of_char_timings = False
@@ -576,11 +579,14 @@ class SynthesizeStream(tts.SynthesizeStream):
                             chars = alignment.get("chars", [])
                             durations = alignment.get("charDurationsMs", [])
                             AppConfig().playout_buffer += "".join(chars)
+                            logger.info(
+                                f"just added to playout_buffer, current={AppConfig().playout_buffer}"
+                            )
                             AppConfig().char_timings.extend(durations)
                             AppConfig().was_last_batch_of_char_timings = data.get(
                                 "isFinal", False
                             )
-                            
+
                             received_text_to_print = "".join(
                                 alignment.get("chars", [])
                             ).replace(" ", "")

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -568,13 +568,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                         received_text_to_print = ""
                         if alignment := data.get("normalizedAlignment"):
                             # Add character timing data to the forwarder
-                            if AppConfig().was_last_batch_of_char_timings:
-                                logger.info(
-                                    f"just cleared playout_buffer, current={AppConfig().playout_buffer}"
-                                )
-                                AppConfig().playout_buffer = ""
-                                AppConfig().char_timings = []
-                                AppConfig().was_last_batch_of_char_timings = False
 
                             # Store characters and their durations together
                             chars = alignment.get("chars", [])
@@ -584,9 +577,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                                 f"just added to playout_buffer, current={AppConfig().playout_buffer}"
                             )
                             AppConfig().char_timings.extend(durations)
-                            AppConfig().was_last_batch_of_char_timings = data.get(
-                                "isFinal", False
-                            )
 
                             received_text_to_print = "".join(
                                 alignment.get("chars", [])

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -566,6 +566,21 @@ class SynthesizeStream(tts.SynthesizeStream):
                     if data.get("audio"):
                         received_text_to_print = ""
                         if alignment := data.get("normalizedAlignment"):
+                            # Add character timing data to the forwarder
+                            if AppConfig().was_last_batch_of_char_timings:
+                                AppConfig().playout_buffer = ""
+                                AppConfig().char_timings = []
+                                AppConfig().was_last_batch_of_char_timings = False
+
+                            # Store characters and their durations together
+                            chars = alignment.get("chars", [])
+                            durations = alignment.get("charDurationsMs", [])
+                            AppConfig().playout_buffer += "".join(chars)
+                            AppConfig().char_timings.extend(durations)
+                            AppConfig().was_last_batch_of_char_timings = data.get(
+                                "isFinal", False
+                            )
+                            
                             received_text_to_print = "".join(
                                 alignment.get("chars", [])
                             ).replace(" ", "")

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -563,6 +563,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                         continue
 
                     data = json.loads(msg.data)
+                    logger.info(f"data: {data}")
                     if data.get("audio"):
                         received_text_to_print = ""
                         if alignment := data.get("normalizedAlignment"):


### PR DESCRIPTION
- Introduced `_get_spoken_text_at_time` to fetch spoken text based on elapsed time.
- Added `_get_current_spoken_text` to retrieve text spoken so far.
- Updated `collected_text` in `_play_speech` to use the new method for current spoken text.
- Enhanced TTS forwarder to manage character timings and playout buffer for accurate speech synthesis.