### PR TITLE
Measure Transcription latency independent of VAD

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -62,6 +62,8 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
         self._last_final_transcript_time: float = 0
         self._audio_transcript = ""
         self._last_language: str | None = None
+        self._audio_stream_start_time: float | None = None
+        self._last_transcript_end_time: float = 0
         self._vad_graph = tracing.Tracing.add_graph(
             title="vad",
             x_label="time",
@@ -83,6 +85,9 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
         self.update_vad(None)
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
+        if self._audio_stream_start_time is None:
+            self._audio_stream_start_time = time.time()
+
         if self._stt_ch is not None:
             self._stt_ch.send_nowait(frame)
 
@@ -102,6 +107,7 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
     def update_stt(self, stt: io.STTNode | None) -> None:
         self._stt = stt
         if stt:
+            self._audio_stream_start_time = None  # Reset when STT is updated
             self._stt_ch = aio.Chan[rtc.AudioFrame]()
             self._stt_atask = asyncio.create_task(
                 self._stt_task(stt, self._stt_ch, self._stt_atask)
@@ -147,6 +153,9 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
             self._last_final_transcript_time = time.time()
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
+
+            if hasattr(ev.alternatives[0], "end_time") and ev.alternatives[0].end_time > 0:
+                self._last_transcript_end_time = ev.alternatives[0].end_time
 
             if not self._speaking:
                 if not self._vad:
@@ -214,12 +223,24 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
             )
 
             tracing.Tracing.log_event("end of user turn", {"transcript": self._audio_transcript})
+
+            transcription_delay = 0.0
+            if self._audio_stream_start_time and self._last_transcript_end_time > 0:
+                actual_speech_end_time = (
+                    self._audio_stream_start_time + self._last_transcript_end_time
+                )
+                transcription_delay = max(
+                    self._last_final_transcript_time - actual_speech_end_time, 0
+                )
+            else:
+                transcription_delay = max(
+                    self._last_final_transcript_time - self._last_speaking_time, 0
+                )
+
             eou_metrics = metrics.EOUMetrics(
                 timestamp=time.time(),
                 end_of_utterance_delay=time.time() - self._last_speaking_time,
-                transcription_delay=max(
-                    self._last_final_transcript_time - self._last_speaking_time, 0
-                ),
+                transcription_delay=transcription_delay,
             )
             self.emit("metrics_collected", eou_metrics)
             await self._hooks.on_end_of_turn(self._audio_transcript)

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -229,17 +229,15 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
                 actual_speech_end_time = (
                     self._audio_stream_start_time + self._last_transcript_end_time
                 )
-                transcription_delay = max(
-                    self._last_final_transcript_time - actual_speech_end_time, 0
-                )
             else:
-                transcription_delay = max(
-                    self._last_final_transcript_time - self._last_speaking_time, 0
-                )
+                actual_speech_end_time = self._last_speaking_time
+
+            transcription_delay = max(self._last_final_transcript_time - actual_speech_end_time, 0)
+            end_of_utterance_delay = max(time.time() - actual_speech_end_time, 0)
 
             eou_metrics = metrics.EOUMetrics(
                 timestamp=time.time(),
-                end_of_utterance_delay=time.time() - self._last_speaking_time,
+                end_of_utterance_delay=end_of_utterance_delay,
                 transcription_delay=transcription_delay,
             )
             self.emit("metrics_collected", eou_metrics)


### PR DESCRIPTION
- Previously, transcription latency depended on VAD's silence duration, making metrics inaccurate when transcript was returned too quickly or too late.
- Now using Deepgram's word-level end timestamps to calculate latency from actual speech end to transcript receipt.
- Adds tracking of audio stream start time and speech end timestamps for accurate measurement
- Doesn't affect our VAD or EOU or interruptions (need to work on improving EOU delay seperately).
 
```

10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.425543] {livekit_call.py:1015} ===== E2E LATENCY PER TURN =====
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.425720] {livekit_call.py:1024} Turn 0: EOU Delay = 0.577s, LLM TTFT = 0.007s, Transcription Delay = 0.128s, TTS TTFB = 0.344s, Total = 0.928s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.425720] {livekit_call.py:1024} Turn 0: EOU Delay = 0.577s, LLM TTFT = 0.007s, Transcription Delay = 0.128s, TTS TTFB = 0.344s, Total = 0.928s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.425893] {livekit_call.py:1024} Turn 1: EOU Delay = 0.577s, LLM TTFT = 0.708s, Transcription Delay = 0.072s, TTS TTFB = 0.188s, Total = 1.473s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.425893] {livekit_call.py:1024} Turn 1: EOU Delay = 0.577s, LLM TTFT = 0.708s, Transcription Delay = 0.072s, TTS TTFB = 0.188s, Total = 1.473s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.426078] {livekit_call.py:1024} Turn 2: EOU Delay = 0.576s, LLM TTFT = 1.290s, Transcription Delay = 0.362s, TTS TTFB = 0.300s, Total = 2.166s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.426224] {livekit_call.py:1032} Average E2E Latency: 1.522s over 3 turns
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.426078] {livekit_call.py:1024} Turn 2: EOU Delay = 0.576s, LLM TTFT = 1.290s, Transcription Delay = 0.362s, TTS TTFB = 0.300s, Total = 2.166s
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.426360] {livekit_call.py:1037} ================================
10716c31-17d7-4b57-880d-9a2dc35f1841 [1748564618.426224] {livekit_call.py:1032} Average E2E Latency: 1.522s over 3 turns
```