### PR TITLE
Handle DG Flush when getting start time

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -202,26 +202,7 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
             self._audio_transcript = self._audio_transcript.lstrip()
 
             if hasattr(ev.alternatives[0], "end_time") and ev.alternatives[0].end_time > 0:
-                current_end_time = ev.alternatives[0].end_time
-
-                # # Detect Deepgram flush: cursor reset when timestamp decreases.
-                # # Allow a small negative tolerance to account for floating errors.
-                # if current_end_time + 0.01 < self._last_transcript_end_time:
-                #     # Estimate the wall-clock start time for the new cursor by
-                #     # backing off the current end_time from the time we just
-                #     # received the transcript.
-                #     new_start_time = self._last_final_transcript_time - current_end_time
-                #     self._audio_stream_start_time = new_start_time
-                #     self._audio_stream_start_time_history.append(new_start_time)
-                #     # Limit history size to avoid unbounded growth.
-                #     if len(self._audio_stream_start_time_history) > 20:
-                #         self._audio_stream_start_time_history.pop(0)
-                #     logger.info(
-                #         "Detected STT timestamp reset; updating audio stream start time to %s",
-                #         new_start_time,
-                #     )
-
-                self._last_transcript_end_time = current_end_time
+                self._last_transcript_end_time = ev.alternatives[0].end_time
 
             if not self._speaking:
                 if not self._vad:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -62,6 +62,8 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
         self._last_final_transcript_time: float = 0
         self._audio_transcript = ""
         self._last_language: str | None = None
+        self._audio_stream_start_time: float | None = None
+        self._last_transcript_end_time: float = 0
         self._vad_graph = tracing.Tracing.add_graph(
             title="vad",
             x_label="time",
@@ -83,6 +85,9 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
         self.update_vad(None)
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
+        if self._audio_stream_start_time is None:
+            self._audio_stream_start_time = time.time()
+
         if self._stt_ch is not None:
             self._stt_ch.send_nowait(frame)
 
@@ -102,6 +107,7 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
     def update_stt(self, stt: io.STTNode | None) -> None:
         self._stt = stt
         if stt:
+            self._audio_stream_start_time = None  # Reset when STT is updated
             self._stt_ch = aio.Chan[rtc.AudioFrame]()
             self._stt_atask = asyncio.create_task(
                 self._stt_task(stt, self._stt_ch, self._stt_atask)
@@ -147,6 +153,9 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
             self._last_final_transcript_time = time.time()
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
+
+            if hasattr(ev.alternatives[0], "end_time") and ev.alternatives[0].end_time > 0:
+                self._last_transcript_end_time = ev.alternatives[0].end_time
 
             if not self._speaking:
                 if not self._vad:
@@ -214,12 +223,24 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
             )
 
             tracing.Tracing.log_event("end of user turn", {"transcript": self._audio_transcript})
+
+            transcription_delay = 0.0
+            if self._audio_stream_start_time and self._last_transcript_end_time > 0:
+                actual_speech_end_time = (
+                    self._audio_stream_start_time + self._last_transcript_end_time
+                )
+                transcription_delay = max(
+                    self._last_final_transcript_time - actual_speech_end_time, 0
+                )
+            else:
+                transcription_delay = max(
+                    self._last_final_transcript_time - self._last_speaking_time, 0
+                )
+
             eou_metrics = metrics.EOUMetrics(
                 timestamp=time.time(),
                 end_of_utterance_delay=time.time() - self._last_speaking_time,
-                transcription_delay=max(
-                    self._last_final_transcript_time - self._last_speaking_time, 0
-                ),
+                transcription_delay=transcription_delay,
             )
             self.emit("metrics_collected", eou_metrics)
             await self._hooks.on_end_of_turn(self._audio_transcript)

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -229,17 +229,15 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
                 actual_speech_end_time = (
                     self._audio_stream_start_time + self._last_transcript_end_time
                 )
-                transcription_delay = max(
-                    self._last_final_transcript_time - actual_speech_end_time, 0
-                )
             else:
-                transcription_delay = max(
-                    self._last_final_transcript_time - self._last_speaking_time, 0
-                )
+                actual_speech_end_time = self._last_speaking_time
+
+            transcription_delay = max(self._last_final_transcript_time - actual_speech_end_time, 0)
+            end_of_utterance_delay = max(time.time() - actual_speech_end_time, 0)
 
             eou_metrics = metrics.EOUMetrics(
                 timestamp=time.time(),
-                end_of_utterance_delay=time.time() - self._last_speaking_time,
+                end_of_utterance_delay=end_of_utterance_delay,
                 transcription_delay=transcription_delay,
             )
             self.emit("metrics_collected", eou_metrics)


### PR DESCRIPTION
- Get the right start cursor after DG flush using heuristics.
- [Tested](https://www.notion.so/skwidinc/Metrics-fix-20f314ff651480dfa50bd96149e71ff9?source=copy_link) on a couple of very long calls involving 5+ flushes
