### PR TITLE
Remove VAD heuristic check while calculating transcript latency

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -168,17 +168,6 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
                 failed_candidates,
             )
 
-        # Log candidates and fallback decision.
-        if self._audio_stream_start_time_history and self._last_transcript_end_time > 0:
-            failed_candidates: list[float] = [
-                start + self._last_transcript_end_time
-                for start in self._audio_stream_start_time_history
-            ]
-            logger.info(
-                "STT candidates failed plausibility checks, excluding turn. candidates=%s",
-                failed_candidates,
-            )
-
         return self._last_speaking_time
 
     async def _on_stt_event(self, ev: stt.SpeechEvent) -> None:


### PR DESCRIPTION
- Our VAD is known to be wrong(today), removing excluding a candidate because of discrepancy with that.
- We were excluding perfectly good candidates because our VAD is wrong
```
if abs(candidate - self._last_speaking_time) > 1.0:
                    continue
```