### PR TITLE
fix: close voice session resources on shutdown

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -65,6 +65,7 @@ class AgentActivity(RecognitionHooks):
 
         self._started = False
         self._draining = False
+        self._closed = False
 
         self._current_speech: SpeechHandle | None = None
         self._speech_q: list[tuple[int, float, SpeechHandle]] = []
@@ -365,8 +366,26 @@ class AgentActivity(RecognitionHooks):
 
     async def aclose(self) -> None:
         async with self._lock:
+            if self._closed:
+                return
+
+            self._closed = True
             if not self._draining:
                 logger.warning("task closing without draining")
+                self._draining = True
+
+            handles = [self._current_speech]
+            handles.extend(speech for _, _, speech in self._speech_q)
+            for handle in handles:
+                if handle is not None:
+                    handle.interrupt(force=True)
+
+            self._speech_q.clear()
+            self._wake_up_main_task()
+
+            speech_tasks = list(self._speech_tasks)
+            if speech_tasks:
+                await utils.aio.cancel_and_wait(*speech_tasks)
 
             if self._rt_session is not None:
                 await self._rt_session.aclose()
@@ -378,6 +397,7 @@ class AgentActivity(RecognitionHooks):
                 await utils.aio.cancel_and_wait(self._main_atask)
 
             self._agent._activity = None
+            self._started = False
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
         if not self._started:
@@ -517,7 +537,7 @@ class AgentActivity(RecognitionHooks):
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
         return handle
 
-    def interrupt(self) -> asyncio.Future:
+    def interrupt(self, *, force: bool = False) -> asyncio.Future:
         """Interrupt the current speech generation and any queued speeches.
 
         Returns:
@@ -528,11 +548,11 @@ class AgentActivity(RecognitionHooks):
         current_speech = self._current_speech
 
         if current_speech is not None:
-            current_speech = current_speech.interrupt()
+            current_speech = current_speech.interrupt(force=force)
 
         for speech in self._speech_q:
             _, _, speech = speech
-            speech.interrupt()
+            speech.interrupt(force=force)
 
         if self._rt_session is not None:
             self._rt_session.interrupt()

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -278,11 +278,37 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if not self._started:
                 return
 
+            self._started = False
+
+            if (
+                self._update_activity_atask is not None
+                and self._update_activity_atask is not asyncio.current_task()
+            ):
+                await utils.aio.cancel_and_wait(self._update_activity_atask)
+
+            async with self._activity_lock:
+                activities = []
+                for activity in (
+                    getattr(self, "_next_activity", None),
+                    self._activity,
+                ):
+                    if activity is not None and all(
+                        existing is not activity for existing in activities
+                    ):
+                        activities.append(activity)
+
+                self._next_activity = None
+                self._activity = None
+
+            for activity in activities:
+                await activity.aclose()
+
             if self._forward_audio_atask is not None:
                 await utils.aio.cancel_and_wait(self._forward_audio_atask)
 
             if self._room_io:
                 await self._room_io.aclose()
+                self._room_io = None
 
     def emit(self, event: EventTypes, ev: AgentEvent) -> None:  # type: ignore
         debug.Tracing.log_event(f'agent.on("{event}")', ev.model_dump())

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -290,10 +290,15 @@ class AudioRecognition(rtc.EventEmitter[Literal["metrics_collected"]]):
         if node is None:
             return
 
-        if isinstance(node, AsyncIterable):
-            async for ev in node:
-                assert isinstance(ev, stt.SpeechEvent), "STT node must yield SpeechEvent"
-                await self._on_stt_event(ev)
+        try:
+            if isinstance(node, AsyncIterable):
+                async for ev in node:
+                    assert isinstance(ev, stt.SpeechEvent), "STT node must yield SpeechEvent"
+                    await self._on_stt_event(ev)
+        finally:
+            close = getattr(node, "aclose", None)
+            if close is not None:
+                await close()
 
     @utils.log_exceptions(logger=logger)
     async def _vad_task(

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -71,7 +71,7 @@ class SpeechHandle:
     def done(self) -> bool:
         return self._playout_done_fut.done()
 
-    def interrupt(self) -> SpeechHandle:
+    def interrupt(self, *, force: bool = False) -> SpeechHandle:
         """Interrupt the current speech generation.
 
         Raises:
@@ -80,7 +80,7 @@ class SpeechHandle:
         Returns:
             SpeechHandle: The same speech handle that was interrupted.
         """
-        if not self._allow_interruptions:
+        if not force and not self._allow_interruptions:
             raise RuntimeError("This generation handle does not allow interruptions")
 
         if self.done():

--- a/tests/test_voice_cleanup.py
+++ b/tests/test_voice_cleanup.py
@@ -1,0 +1,111 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from livekit.agents import stt
+from livekit.agents.voice.agent import ModelSettings
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.agent_session import AgentSession
+from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+
+class _OneEventStream:
+    def __init__(self) -> None:
+        self._yielded = False
+        self.close_calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._yielded:
+            await asyncio.Event().wait()
+
+        self._yielded = True
+        return stt.SpeechEvent(type=stt.SpeechEventType.FINAL_TRANSCRIPT)
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_audio_recognition_closes_stt_node_when_cancelled_during_event_handling():
+    recognition = AudioRecognition.__new__(AudioRecognition)
+    stream = _OneEventStream()
+    handling_event = asyncio.Event()
+
+    async def stt_node(_audio_input, _model_settings: ModelSettings):
+        return stream
+
+    async def on_stt_event(_event: stt.SpeechEvent) -> None:
+        handling_event.set()
+        await asyncio.Event().wait()
+
+    recognition._on_stt_event = on_stt_event
+    task = asyncio.create_task(recognition._stt_task(stt_node, object(), None))
+    await handling_event.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_force_interrupts_speech_and_closes_recognition():
+    activity = AgentActivity.__new__(AgentActivity)
+    current_speech = SpeechHandle.create(allow_interruptions=False)
+    queued_speech = SpeechHandle.create(allow_interruptions=False)
+    speech_task = asyncio.create_task(asyncio.Event().wait())
+    main_task = asyncio.create_task(asyncio.Event().wait())
+    recognition = SimpleNamespace(aclose=AsyncMock())
+    agent = SimpleNamespace(_activity=activity)
+
+    activity._lock = asyncio.Lock()
+    activity._closed = False
+    activity._draining = False
+    activity._started = True
+    activity._current_speech = current_speech
+    activity._speech_q = [(SpeechHandle.SPEECH_PRIORITY_NORMAL, 0.0, queued_speech)]
+    activity._speech_tasks = [speech_task]
+    activity._q_updated = asyncio.Event()
+    activity._rt_session = None
+    activity._audio_recognition = recognition
+    activity._main_atask = main_task
+    activity._agent = agent
+
+    await activity.aclose()
+    await activity.aclose()
+
+    assert current_speech.interrupted
+    assert queued_speech.interrupted
+    assert speech_task.cancelled()
+    assert main_task.cancelled()
+    recognition.aclose.assert_awaited_once()
+    assert agent._activity is None
+
+
+@pytest.mark.asyncio
+async def test_agent_session_closes_activity_before_room_io_once():
+    close_order = []
+
+    async def close_activity() -> None:
+        close_order.append("activity")
+
+    async def close_room() -> None:
+        close_order.append("room")
+
+    session = AgentSession(stt=None, vad=None, llm=None, tts=None)
+    session._started = True
+    session._activity = SimpleNamespace(aclose=AsyncMock(side_effect=close_activity))
+    session._next_activity = None
+    session._room_io = SimpleNamespace(aclose=AsyncMock(side_effect=close_room))
+
+    await session.aclose()
+    await session.aclose()
+
+    assert close_order == ["activity", "room"]


### PR DESCRIPTION
## Summary

- make AgentSession own and close active AgentActivity instances before RoomIO
- force-interrupt queued/current speech and cancel activity speech tasks during immediate teardown
- always close the concrete STT node when AudioRecognition exits
- make activity and session teardown idempotent

## Why

Cancelling AudioRecognition while it is handling an STT event can leave the async STT node suspended at a yield. The node then retains the provider stream and WebSocket. AgentSession also did not close AgentActivity, so recognition teardown was not guaranteed on session shutdown.

## Tests

- `tests/test_voice_cleanup.py`: 3 passed
- `tests/test_stt_fallback.py`: 3 passed
- Ruff and formatting checks passed for changed files